### PR TITLE
Add support for failing check on HTTP error responses

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -23,6 +23,9 @@ async function run() {
       .then((res) => {
         // output the status
         core.setOutput('statusCode', res.status);
+        // throw error on error status codes
+        if (res.status >= 400)
+            throw new Error(`Failing with code: ${res.status}`)
         // report on the status code
         core.info(`Received status code: ${res.status}`);
         // debug end


### PR DESCRIPTION
This PR fixes #22 by throwing an error when a server responds with a failing status code.

According to [HTTP response status codes on MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status), `400` to `499` are client errors and `500` to `599` are server errors. In this PR, the status check is failed when such an HTTP status is responded with.