### PR TITLE
bump action from Node12 to Node16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -21,5 +21,5 @@ outputs:
   status: 
     description: 'The status of the webhook event'
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/main.js'


### PR DESCRIPTION
The GitHub Actions workflow gives the following annotation while running the action:

> Node.js 12 actions are deprecated. For more information see: github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12.

Signed-off-by: Enes <ahmedenesturan@gmail.com>